### PR TITLE
docs: add lead-maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,9 @@
 
 A javascript implementation of the rendezvous protocol for libp2p
 
+
+## Lead Maintainer
+
+[Vasco Santos](https://github.com/vasco-santos).
+
 See https://github.com/libp2p/specs/pull/44 for more details

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "libp2p-rendezvous",
   "version": "0.0.0",
   "description": "A javascript implementation of the rendezvous protocol for libp2p",
+  "leadMaintainer": "Vasco Santos <vasco.santos@moxy.studio>",
   "main": "index.js",
   "scripts": {
     "test": "aegir test"


### PR DESCRIPTION
In the context of https://github.com/ipfs/pm/issues/600, [js-libp2p#259](https://github.com/libp2p/js-libp2p/issues/259) and [js-libp2p/pull/265](https://github.com/libp2p/js-libp2p/pull/265).

Needs:

- [x] Update each package.json and README.md to have a leadMaintainer field.
- [x] Update [packages table](https://github.com/libp2p/js-libp2p/blob/3226632d83e8684e32b00eeb398b21158b94586d/README.md#packages) - [js-libp2p#265](https://github.com/libp2p/js-libp2p/pull/265)
- [x] Grant publish permission to the Maintainer